### PR TITLE
feat!: use taskTimeout in SempahoreTimeoutOptions

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.10.0",
+      "version": "2.63.0",
       "type": "build"
     },
     {
@@ -107,7 +107,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.10.0",
+      "version": "^2.63.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -4,7 +4,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   author: 'Ej Wang',
   authorAddress: 'ej.wang.devs@gmail.com',
 
-  cdkVersion: '2.10.0',
+  cdkVersion: '2.63.0',
 
   autoApproveOptions: {
     allowedUsernames: ['flyingImer'],

--- a/API.md
+++ b/API.md
@@ -1012,6 +1012,7 @@ const acquireOptions: AcquireOptions = { ... }
 | <code><a href="#cdk-concurrency-controller.AcquireOptions.property.name">name</a></code> | <code>string</code> | The name for the semaphore. |
 | <code><a href="#cdk-concurrency-controller.AcquireOptions.property.userId">userId</a></code> | <code>string</code> | The semaphore user id to acquire/release resource usage. |
 | <code><a href="#cdk-concurrency-controller.AcquireOptions.property.nextTryWaitTime">nextTryWaitTime</a></code> | <code>string</code> | Wait a fixed amount of time (in second) for another try to acquire semaphore if not acquired in previous tries. |
+| <code><a href="#cdk-concurrency-controller.AcquireOptions.property.taskTimeout">taskTimeout</a></code> | <code>aws-cdk-lib.aws_stepfunctions.Timeout</code> | Maximum run time for the execution. |
 | <code><a href="#cdk-concurrency-controller.AcquireOptions.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | Maximum run time for the execution. |
 
 ---
@@ -1058,7 +1059,22 @@ Wait a fixed amount of time (in second) for another try to acquire semaphore if 
 
 ---
 
-##### `timeout`<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.AcquireOptions.property.timeout"></a>
+##### `taskTimeout`<sup>Optional</sup> <a name="taskTimeout" id="cdk-concurrency-controller.AcquireOptions.property.taskTimeout"></a>
+
+```typescript
+public readonly taskTimeout: Timeout;
+```
+
+- *Type:* aws-cdk-lib.aws_stepfunctions.Timeout
+- *Default:* No timeout
+
+Maximum run time for the execution.
+
+---
+
+##### ~~`timeout`~~<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.AcquireOptions.property.timeout"></a>
+
+- *Deprecated:* Use taskTimeout instead
 
 ```typescript
 public readonly timeout: Duration;
@@ -1312,13 +1328,29 @@ const acquireViaStartExecutionFragmentProps: AcquireViaStartExecutionFragmentPro
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-concurrency-controller.AcquireViaStartExecutionFragmentProps.property.taskTimeout">taskTimeout</a></code> | <code>aws-cdk-lib.aws_stepfunctions.Timeout</code> | Maximum run time for the execution. |
 | <code><a href="#cdk-concurrency-controller.AcquireViaStartExecutionFragmentProps.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | Maximum run time for the execution. |
 | <code><a href="#cdk-concurrency-controller.AcquireViaStartExecutionFragmentProps.property.input">input</a></code> | <code><a href="#cdk-concurrency-controller.AcquireSemaphoreTaskInput">AcquireSemaphoreTaskInput</a></code> | *No description.* |
 | <code><a href="#cdk-concurrency-controller.AcquireViaStartExecutionFragmentProps.property.stateMachine">stateMachine</a></code> | <code>aws-cdk-lib.aws_stepfunctions.IStateMachine</code> | The Step Functions state machine to start the execution on. |
 
 ---
 
-##### `timeout`<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.AcquireViaStartExecutionFragmentProps.property.timeout"></a>
+##### `taskTimeout`<sup>Optional</sup> <a name="taskTimeout" id="cdk-concurrency-controller.AcquireViaStartExecutionFragmentProps.property.taskTimeout"></a>
+
+```typescript
+public readonly taskTimeout: Timeout;
+```
+
+- *Type:* aws-cdk-lib.aws_stepfunctions.Timeout
+- *Default:* No timeout
+
+Maximum run time for the execution.
+
+---
+
+##### ~~`timeout`~~<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.AcquireViaStartExecutionFragmentProps.property.timeout"></a>
+
+- *Deprecated:* Use taskTimeout instead
 
 ```typescript
 public readonly timeout: Duration;
@@ -1450,6 +1482,7 @@ const releaseOptions: ReleaseOptions = { ... }
 | <code><a href="#cdk-concurrency-controller.ReleaseOptions.property.name">name</a></code> | <code>string</code> | The name for the semaphore. |
 | <code><a href="#cdk-concurrency-controller.ReleaseOptions.property.userId">userId</a></code> | <code>string</code> | The semaphore user id to acquire/release resource usage. |
 | <code><a href="#cdk-concurrency-controller.ReleaseOptions.property.checkSemaphoreUseFirst">checkSemaphoreUseFirst</a></code> | <code>boolean</code> | Check if the semaphore use exists before trying to release it. |
+| <code><a href="#cdk-concurrency-controller.ReleaseOptions.property.taskTimeout">taskTimeout</a></code> | <code>aws-cdk-lib.aws_stepfunctions.Timeout</code> | Maximum run time for the execution. |
 | <code><a href="#cdk-concurrency-controller.ReleaseOptions.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | Maximum run time for the execution. |
 
 ---
@@ -1501,7 +1534,22 @@ see more about hot partition: https://aws.amazon.com/premiumsupport/knowledge-ce
 
 ---
 
-##### `timeout`<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.ReleaseOptions.property.timeout"></a>
+##### `taskTimeout`<sup>Optional</sup> <a name="taskTimeout" id="cdk-concurrency-controller.ReleaseOptions.property.taskTimeout"></a>
+
+```typescript
+public readonly taskTimeout: Timeout;
+```
+
+- *Type:* aws-cdk-lib.aws_stepfunctions.Timeout
+- *Default:* No timeout
+
+Maximum run time for the execution.
+
+---
+
+##### ~~`timeout`~~<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.ReleaseOptions.property.timeout"></a>
+
+- *Deprecated:* Use taskTimeout instead
 
 ```typescript
 public readonly timeout: Duration;
@@ -1730,13 +1778,29 @@ const releaseViaStartExecutionFragmentProps: ReleaseViaStartExecutionFragmentPro
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-concurrency-controller.ReleaseViaStartExecutionFragmentProps.property.taskTimeout">taskTimeout</a></code> | <code>aws-cdk-lib.aws_stepfunctions.Timeout</code> | Maximum run time for the execution. |
 | <code><a href="#cdk-concurrency-controller.ReleaseViaStartExecutionFragmentProps.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | Maximum run time for the execution. |
 | <code><a href="#cdk-concurrency-controller.ReleaseViaStartExecutionFragmentProps.property.input">input</a></code> | <code><a href="#cdk-concurrency-controller.ReleaseSemaphoreTaskInput">ReleaseSemaphoreTaskInput</a></code> | *No description.* |
 | <code><a href="#cdk-concurrency-controller.ReleaseViaStartExecutionFragmentProps.property.stateMachine">stateMachine</a></code> | <code>aws-cdk-lib.aws_stepfunctions.IStateMachine</code> | The Step Functions state machine to start the execution on. |
 
 ---
 
-##### `timeout`<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.ReleaseViaStartExecutionFragmentProps.property.timeout"></a>
+##### `taskTimeout`<sup>Optional</sup> <a name="taskTimeout" id="cdk-concurrency-controller.ReleaseViaStartExecutionFragmentProps.property.taskTimeout"></a>
+
+```typescript
+public readonly taskTimeout: Timeout;
+```
+
+- *Type:* aws-cdk-lib.aws_stepfunctions.Timeout
+- *Default:* No timeout
+
+Maximum run time for the execution.
+
+---
+
+##### ~~`timeout`~~<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.ReleaseViaStartExecutionFragmentProps.property.timeout"></a>
+
+- *Deprecated:* Use taskTimeout instead
 
 ```typescript
 public readonly timeout: Duration;
@@ -1833,13 +1897,29 @@ const semaphoreStateMachineProps: SemaphoreStateMachineProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-concurrency-controller.SemaphoreStateMachineProps.property.taskTimeout">taskTimeout</a></code> | <code>aws-cdk-lib.aws_stepfunctions.Timeout</code> | Maximum run time for the execution. |
 | <code><a href="#cdk-concurrency-controller.SemaphoreStateMachineProps.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | Maximum run time for the execution. |
 | <code><a href="#cdk-concurrency-controller.SemaphoreStateMachineProps.property.logs">logs</a></code> | <code>aws-cdk-lib.aws_stepfunctions.LogOptions</code> | Defines what execution history events are logged and where they are logged. |
 | <code><a href="#cdk-concurrency-controller.SemaphoreStateMachineProps.property.tracingEnabled">tracingEnabled</a></code> | <code>boolean</code> | Specifies whether Amazon X-Ray tracing is enabled for this state machine. |
 
 ---
 
-##### `timeout`<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.SemaphoreStateMachineProps.property.timeout"></a>
+##### `taskTimeout`<sup>Optional</sup> <a name="taskTimeout" id="cdk-concurrency-controller.SemaphoreStateMachineProps.property.taskTimeout"></a>
+
+```typescript
+public readonly taskTimeout: Timeout;
+```
+
+- *Type:* aws-cdk-lib.aws_stepfunctions.Timeout
+- *Default:* No timeout
+
+Maximum run time for the execution.
+
+---
+
+##### ~~`timeout`~~<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.SemaphoreStateMachineProps.property.timeout"></a>
+
+- *Deprecated:* Use taskTimeout instead
 
 ```typescript
 public readonly timeout: Duration;
@@ -1944,11 +2024,27 @@ const semaphoreTimeoutOptions: SemaphoreTimeoutOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-concurrency-controller.SemaphoreTimeoutOptions.property.taskTimeout">taskTimeout</a></code> | <code>aws-cdk-lib.aws_stepfunctions.Timeout</code> | Maximum run time for the execution. |
 | <code><a href="#cdk-concurrency-controller.SemaphoreTimeoutOptions.property.timeout">timeout</a></code> | <code>aws-cdk-lib.Duration</code> | Maximum run time for the execution. |
 
 ---
 
-##### `timeout`<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.SemaphoreTimeoutOptions.property.timeout"></a>
+##### `taskTimeout`<sup>Optional</sup> <a name="taskTimeout" id="cdk-concurrency-controller.SemaphoreTimeoutOptions.property.taskTimeout"></a>
+
+```typescript
+public readonly taskTimeout: Timeout;
+```
+
+- *Type:* aws-cdk-lib.aws_stepfunctions.Timeout
+- *Default:* No timeout
+
+Maximum run time for the execution.
+
+---
+
+##### ~~`timeout`~~<sup>Optional</sup> <a name="timeout" id="cdk-concurrency-controller.SemaphoreTimeoutOptions.property.timeout"></a>
+
+- *Deprecated:* Use taskTimeout instead
 
 ```typescript
 public readonly timeout: Duration;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "all-contributors-cli": "^6.24.0",
-    "aws-cdk-lib": "2.77.0",
+    "aws-cdk-lib": "2.63.0",
     "constructs": "10.2.12",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
     "organization": false
   },
   "devDependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.77.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.63.0-alpha.0",
     "@types/jest": "^27.5.2",
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "all-contributors-cli": "^6.24.0",
     "aws-cdk-lib": "2.63.0",
-    "constructs": "10.2.12",
+    "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^2.7.1",
@@ -64,8 +64,8 @@
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": ">=2.63.0 <3",
-    "constructs": "^10.2.12"
+    "aws-cdk-lib": "^2.63.0",
+    "constructs": "^10.0.5"
   },
   "keywords": [
     "cdk"

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
     "organization": false
   },
   "devDependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "^2.52.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.77.0-alpha.0",
     "@types/jest": "^27.5.2",
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "all-contributors-cli": "^6.24.0",
-    "aws-cdk-lib": "2.10.0",
-    "constructs": "10.0.5",
+    "aws-cdk-lib": "2.77.0",
+    "constructs": "10.2.12",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^2.7.1",
@@ -64,8 +64,8 @@
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.10.0",
-    "constructs": "^10.0.5"
+    "aws-cdk-lib": ">=2.63.0 <3",
+    "constructs": "^10.2.12"
   },
   "keywords": [
     "cdk"

--- a/src/private/types.ts
+++ b/src/private/types.ts
@@ -1,0 +1,17 @@
+import { Duration } from 'aws-cdk-lib';
+import { Timeout } from 'aws-cdk-lib/aws-stepfunctions';
+
+export interface SemaphoreTimeoutOptions {
+  /**
+   * Maximum run time for the execution.
+   *
+   * @deprecated Use taskTimeout instead
+   * @default No timeout
+   */
+  readonly timeout?: Duration;
+  /**
+   * Maximum run time for the execution.
+   * @default No timeout
+   */
+  readonly taskTimeout?: Timeout;
+}

--- a/src/private/utils.ts
+++ b/src/private/utils.ts
@@ -1,4 +1,5 @@
-import { isPositiveInteger, JsonPath } from 'aws-cdk-lib/aws-stepfunctions';
+import { isPositiveInteger, JsonPath, Timeout } from 'aws-cdk-lib/aws-stepfunctions';
+import { SemaphoreTimeoutOptions } from './types';
 
 /**
  * Check if the given literal string is a non negative integer value at compile time.
@@ -12,3 +13,13 @@ export const isDeterminedNonNegativeInteger = (value: string): boolean => {
   const num = new Number(value);
   return !Number.isNaN(num) && isPositiveInteger(num.valueOf());
 };
+
+/**
+ * As of aws-cdk-lib@2.63.0, `timeout` is a deprecated parameter
+ * and we should be using taskTimeout instead.
+ *
+ * @param props SemaphoreTimeoutOptions
+ * @returns A value for `taskTimeout`
+ */
+export const toTaskTimeout = ({ taskTimeout, timeout }: SemaphoreTimeoutOptions): undefined | Timeout =>
+  taskTimeout ?? (timeout ? Timeout.duration(timeout) : undefined);

--- a/test/__snapshots__/construct.test.ts.snap
+++ b/test/__snapshots__/construct.test.ts.snap
@@ -46,6 +46,7 @@ Object {
       "Catch": null,
       "Comment": "Get info from DDB for the semaphore item.",
       "HeartbeatSeconds": null,
+      "HeartbeatSecondsPath": null,
       "InputPath": null,
       "Next": "CheckIfFoundSemaphore",
       "OutputPath": null,
@@ -75,6 +76,7 @@ Object {
         },
       ],
       "TimeoutSeconds": null,
+      "TimeoutSecondsPath": null,
       "Type": "Task",
     },
     "InitializeSemaphore": Object {
@@ -84,11 +86,12 @@ Object {
             "States.ALL",
           ],
           "Next": "TryToAcquireSemaphore",
-          "ResultPath": null,
+          "ResultPath": "\${Token[NORMALIZED_ID]}",
         },
       ],
       "Comment": "This state handles the case where an item hasn't been created for this semaphore yet. In that case, it will insert an initial item that includes the semaphore name as the key and CurrentInUseCount of 0. The Put to DynamoDB includes a conditional expression to fail if the an item with that key already exists, which avoids a race condition if multiple executions start at the same time. There are other reasons that the previous state could fail and end up here, so this is safe in those cases too.",
       "HeartbeatSeconds": null,
+      "HeartbeatSecondsPath": null,
       "InputPath": null,
       "Next": "TryToAcquireSemaphore",
       "OutputPath": null,
@@ -110,9 +113,10 @@ Object {
         "TableName": "\${Token[NORMALIZED_ID]}",
       },
       "Resource": "arn:\${Token[NORMALIZED_ID]}:states:::dynamodb:putItem",
-      "ResultPath": null,
+      "ResultPath": "\${Token[NORMALIZED_ID]}",
       "Retry": null,
       "TimeoutSeconds": null,
+      "TimeoutSecondsPath": null,
       "Type": "Task",
     },
     "PrepareInput": Object {
@@ -135,7 +139,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": null,
+      "ResultPath": "\${Token[NORMALIZED_ID]}",
       "Type": "Pass",
     },
     "SemaphoreAcquisitionConfirmedContinue": Object {
@@ -145,7 +149,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": null,
+      "ResultPath": "\${Token[NORMALIZED_ID]}",
       "Type": "Pass",
     },
     "TryToAcquireSemaphore": Object {
@@ -167,6 +171,7 @@ Object {
       ],
       "Comment": "Try to acquire a semaphore using a conditional update to DynamoDB. This update will do two things: 1) increment a counter for the number of held semaphores and 2) add an attribute to the DynamoDB Item with a unique key for this execution and with a value of the time when the semaphore was Acquired. The Update includes a conditional expression that will fail under two circumstances: 1) if the maximum number of semaphores have already been distributed or 2) if the current execution already owns a semaphore. The latter check is important to ensure the same execution doesn't increase the counter more than once. If either of these conditions are not met, then the task will fail with a DynamoDB.ConditionalCheckFailedException error, retry a few times, then if it is still not successful, it will move off to another branch of the workflow. If this is the first time that a given semaphoreName has been used, there will not be a row in DynamoDB, so the update will fail with DynamoDB.AmazonDynamoDBException. In that case, this state sends the workflow to state that will create that row to initialize.",
       "HeartbeatSeconds": null,
+      "HeartbeatSecondsPath": null,
       "InputPath": null,
       "Next": "SemaphoreAcquired",
       "OutputPath": null,
@@ -197,7 +202,7 @@ Object {
         "UpdateExpression": "SET #currentInUseCount = #currentInUseCount + :increase, #semaphoreUserId = :semaphoreUseAcquiredTime",
       },
       "Resource": "arn:\${Token[NORMALIZED_ID]}:states:::dynamodb:updateItem",
-      "ResultPath": null,
+      "ResultPath": "\${Token[NORMALIZED_ID]}",
       "Retry": Array [
         Object {
           "BackoffRate": null,
@@ -217,6 +222,7 @@ Object {
         },
       ],
       "TimeoutSeconds": null,
+      "TimeoutSecondsPath": null,
       "Type": "Task",
     },
     "WaitToAcquireSemaphore": Object {
@@ -239,6 +245,7 @@ Object {
       "Comment": null,
       "End": true,
       "HeartbeatSeconds": null,
+      "HeartbeatSecondsPath": null,
       "InputPath": null,
       "OutputPath": null,
       "Parameters": Object {
@@ -255,6 +262,7 @@ Object {
       "ResultPath": null,
       "Retry": null,
       "TimeoutSeconds": null,
+      "TimeoutSecondsPath": null,
       "Type": "Task",
     },
   },
@@ -308,6 +316,7 @@ Object {
       "Catch": null,
       "Comment": "Get info from DDB for the semaphore item.",
       "HeartbeatSeconds": null,
+      "HeartbeatSecondsPath": null,
       "InputPath": null,
       "Next": "CheckIfFoundSemaphore",
       "OutputPath": null,
@@ -337,6 +346,7 @@ Object {
         },
       ],
       "TimeoutSeconds": null,
+      "TimeoutSecondsPath": null,
       "Type": "Task",
     },
     "ParseOriginalInputSnapshot": Object {
@@ -371,7 +381,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": null,
+      "ResultPath": "\${Token[NORMALIZED_ID]}",
       "Type": "Pass",
     },
     "SemaphoreUseNotFoundContinue": Object {
@@ -381,7 +391,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": null,
+      "ResultPath": "\${Token[NORMALIZED_ID]}",
       "Type": "Pass",
     },
     "TryToReleaseSemaphore": Object {
@@ -391,11 +401,12 @@ Object {
             "DynamoDB.ConditionalCheckFailedException",
           ],
           "Next": "SemaphoreUseNotFoundContinue",
-          "ResultPath": null,
+          "ResultPath": "\${Token[NORMALIZED_ID]}",
         },
       ],
       "Comment": "If this semaphoreUserId is still there, then clean it up and release the semaphore",
       "HeartbeatSeconds": null,
+      "HeartbeatSecondsPath": null,
       "InputPath": null,
       "Next": "SemaphoreReleased",
       "OutputPath": null,
@@ -420,7 +431,7 @@ Object {
         "UpdateExpression": "SET #currentInUseCount = #currentInUseCount - :decrease REMOVE #semaphoreUserId",
       },
       "Resource": "arn:\${Token[NORMALIZED_ID]}:states:::dynamodb:updateItem",
-      "ResultPath": null,
+      "ResultPath": "\${Token[NORMALIZED_ID]}",
       "Retry": Array [
         Object {
           "BackoffRate": null,
@@ -440,6 +451,7 @@ Object {
         },
       ],
       "TimeoutSeconds": null,
+      "TimeoutSecondsPath": null,
       "Type": "Task",
     },
   },
@@ -458,7 +470,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": null,
+      "ResultPath": "\${Token[NORMALIZED_ID]}",
       "Type": "Pass",
     },
     "SemaphoreUseNotFoundContinue": Object {
@@ -468,7 +480,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": null,
+      "ResultPath": "\${Token[NORMALIZED_ID]}",
       "Type": "Pass",
     },
     "TryToReleaseSemaphore": Object {
@@ -478,11 +490,12 @@ Object {
             "DynamoDB.ConditionalCheckFailedException",
           ],
           "Next": "SemaphoreUseNotFoundContinue",
-          "ResultPath": null,
+          "ResultPath": "\${Token[NORMALIZED_ID]}",
         },
       ],
       "Comment": "If this semaphoreUserId is still there, then clean it up and release the semaphore",
       "HeartbeatSeconds": null,
+      "HeartbeatSecondsPath": null,
       "InputPath": null,
       "Next": "SemaphoreReleased",
       "OutputPath": null,
@@ -507,7 +520,7 @@ Object {
         "UpdateExpression": "SET #currentInUseCount = #currentInUseCount - :decrease REMOVE #semaphoreUserId",
       },
       "Resource": "arn:\${Token[NORMALIZED_ID]}:states:::dynamodb:updateItem",
-      "ResultPath": null,
+      "ResultPath": "\${Token[NORMALIZED_ID]}",
       "Retry": Array [
         Object {
           "BackoffRate": null,
@@ -527,6 +540,7 @@ Object {
         },
       ],
       "TimeoutSeconds": null,
+      "TimeoutSecondsPath": null,
       "Type": "Task",
     },
   },
@@ -543,6 +557,7 @@ Object {
       "Comment": null,
       "End": true,
       "HeartbeatSeconds": null,
+      "HeartbeatSecondsPath": null,
       "InputPath": null,
       "OutputPath": null,
       "Parameters": Object {
@@ -557,6 +572,7 @@ Object {
       "ResultPath": null,
       "Retry": null,
       "TimeoutSeconds": null,
+      "TimeoutSecondsPath": null,
       "Type": "Task",
     },
   },
@@ -586,6 +602,9 @@ Object {
       "ap-south-1": Object {
         "states": "states.ap-south-1.amazonaws.com",
       },
+      "ap-south-2": Object {
+        "states": "states.ap-south-2.amazonaws.com",
+      },
       "ap-southeast-1": Object {
         "states": "states.ap-southeast-1.amazonaws.com",
       },
@@ -607,6 +626,9 @@ Object {
       "eu-central-1": Object {
         "states": "states.eu-central-1.amazonaws.com",
       },
+      "eu-central-2": Object {
+        "states": "states.eu-central-2.amazonaws.com",
+      },
       "eu-north-1": Object {
         "states": "states.eu-north-1.amazonaws.com",
       },
@@ -624,6 +646,9 @@ Object {
       },
       "eu-west-3": Object {
         "states": "states.eu-west-3.amazonaws.com",
+      },
+      "me-central-1": Object {
+        "states": "states.me-central-1.amazonaws.com",
       },
       "me-south-1": Object {
         "states": "states.me-south-1.amazonaws.com",
@@ -669,6 +694,7 @@ Object {
   },
   "Resources": Object {
     "DistributedSemaphoreAcquireSemaphoreStateMachine11CA7A20": Object {
+      "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "DistributedSemaphoreAcquireSemaphoreStateMachineRoleDefaultPolicy8F27372C",
         "DistributedSemaphoreAcquireSemaphoreStateMachineRoleFCBD4625",
@@ -714,6 +740,7 @@ Object {
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
+      "UpdateReplacePolicy": "Delete",
     },
     "DistributedSemaphoreAcquireSemaphoreStateMachineRoleDefaultPolicy8F27372C": Object {
       "Properties": Object {
@@ -838,6 +865,7 @@ Object {
       "Type": "AWS::IAM::Role",
     },
     "DistributedSemaphoreCleanupSemaphoreStateMachine74D1E441": Object {
+      "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "DistributedSemaphoreCleanupSemaphoreStateMachineRoleDefaultPolicyD920CE03",
         "DistributedSemaphoreCleanupSemaphoreStateMachineRole2FB995B5",
@@ -875,6 +903,7 @@ Object {
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
+      "UpdateReplacePolicy": "Delete",
     },
     "DistributedSemaphoreCleanupSemaphoreStateMachineEventsRole911C317B": Object {
       "Properties": Object {
@@ -1012,6 +1041,7 @@ Object {
       "Type": "AWS::IAM::Policy",
     },
     "DistributedSemaphoreReleaseSemaphoreStateMachine15A1EC10": Object {
+      "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "DistributedSemaphoreReleaseSemaphoreStateMachineRoleDefaultPolicy6BAFBCEB",
         "DistributedSemaphoreReleaseSemaphoreStateMachineRole927C85D8",
@@ -1041,6 +1071,7 @@ Object {
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
+      "UpdateReplacePolicy": "Delete",
     },
     "DistributedSemaphoreReleaseSemaphoreStateMachineRole927C85D8": Object {
       "Properties": Object {
@@ -1174,6 +1205,7 @@ Object {
       "UpdateReplacePolicy": "Retain",
     },
     "SemaphoreE4816963": Object {
+      "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "SemaphoreRoleDefaultPolicy3FABCD2F",
         "SemaphoreRole7E0FA103",
@@ -1259,6 +1291,7 @@ Object {
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
+      "UpdateReplacePolicy": "Delete",
     },
     "SemaphoreRole7E0FA103": Object {
       "Properties": Object {

--- a/test/__snapshots__/construct.test.ts.snap
+++ b/test/__snapshots__/construct.test.ts.snap
@@ -86,7 +86,7 @@ Object {
             "States.ALL",
           ],
           "Next": "TryToAcquireSemaphore",
-          "ResultPath": "\${Token[NORMALIZED_ID]}",
+          "ResultPath": null,
         },
       ],
       "Comment": "This state handles the case where an item hasn't been created for this semaphore yet. In that case, it will insert an initial item that includes the semaphore name as the key and CurrentInUseCount of 0. The Put to DynamoDB includes a conditional expression to fail if the an item with that key already exists, which avoids a race condition if multiple executions start at the same time. There are other reasons that the previous state could fail and end up here, so this is safe in those cases too.",
@@ -113,7 +113,7 @@ Object {
         "TableName": "\${Token[NORMALIZED_ID]}",
       },
       "Resource": "arn:\${Token[NORMALIZED_ID]}:states:::dynamodb:putItem",
-      "ResultPath": "\${Token[NORMALIZED_ID]}",
+      "ResultPath": null,
       "Retry": null,
       "TimeoutSeconds": null,
       "TimeoutSecondsPath": null,
@@ -139,7 +139,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": "\${Token[NORMALIZED_ID]}",
+      "ResultPath": null,
       "Type": "Pass",
     },
     "SemaphoreAcquisitionConfirmedContinue": Object {
@@ -149,7 +149,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": "\${Token[NORMALIZED_ID]}",
+      "ResultPath": null,
       "Type": "Pass",
     },
     "TryToAcquireSemaphore": Object {
@@ -202,7 +202,7 @@ Object {
         "UpdateExpression": "SET #currentInUseCount = #currentInUseCount + :increase, #semaphoreUserId = :semaphoreUseAcquiredTime",
       },
       "Resource": "arn:\${Token[NORMALIZED_ID]}:states:::dynamodb:updateItem",
-      "ResultPath": "\${Token[NORMALIZED_ID]}",
+      "ResultPath": null,
       "Retry": Array [
         Object {
           "BackoffRate": null,
@@ -381,7 +381,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": "\${Token[NORMALIZED_ID]}",
+      "ResultPath": null,
       "Type": "Pass",
     },
     "SemaphoreUseNotFoundContinue": Object {
@@ -391,7 +391,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": "\${Token[NORMALIZED_ID]}",
+      "ResultPath": null,
       "Type": "Pass",
     },
     "TryToReleaseSemaphore": Object {
@@ -401,7 +401,7 @@ Object {
             "DynamoDB.ConditionalCheckFailedException",
           ],
           "Next": "SemaphoreUseNotFoundContinue",
-          "ResultPath": "\${Token[NORMALIZED_ID]}",
+          "ResultPath": null,
         },
       ],
       "Comment": "If this semaphoreUserId is still there, then clean it up and release the semaphore",
@@ -431,7 +431,7 @@ Object {
         "UpdateExpression": "SET #currentInUseCount = #currentInUseCount - :decrease REMOVE #semaphoreUserId",
       },
       "Resource": "arn:\${Token[NORMALIZED_ID]}:states:::dynamodb:updateItem",
-      "ResultPath": "\${Token[NORMALIZED_ID]}",
+      "ResultPath": null,
       "Retry": Array [
         Object {
           "BackoffRate": null,
@@ -470,7 +470,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": "\${Token[NORMALIZED_ID]}",
+      "ResultPath": null,
       "Type": "Pass",
     },
     "SemaphoreUseNotFoundContinue": Object {
@@ -480,7 +480,7 @@ Object {
       "OutputPath": null,
       "Parameters": null,
       "Result": null,
-      "ResultPath": "\${Token[NORMALIZED_ID]}",
+      "ResultPath": null,
       "Type": "Pass",
     },
     "TryToReleaseSemaphore": Object {
@@ -490,7 +490,7 @@ Object {
             "DynamoDB.ConditionalCheckFailedException",
           ],
           "Next": "SemaphoreUseNotFoundContinue",
-          "ResultPath": "\${Token[NORMALIZED_ID]}",
+          "ResultPath": null,
         },
       ],
       "Comment": "If this semaphoreUserId is still there, then clean it up and release the semaphore",
@@ -520,7 +520,7 @@ Object {
         "UpdateExpression": "SET #currentInUseCount = #currentInUseCount - :decrease REMOVE #semaphoreUserId",
       },
       "Resource": "arn:\${Token[NORMALIZED_ID]}:states:::dynamodb:updateItem",
-      "ResultPath": "\${Token[NORMALIZED_ID]}",
+      "ResultPath": null,
       "Retry": Array [
         Object {
           "BackoffRate": null,
@@ -626,9 +626,6 @@ Object {
       "eu-central-1": Object {
         "states": "states.eu-central-1.amazonaws.com",
       },
-      "eu-central-2": Object {
-        "states": "states.eu-central-2.amazonaws.com",
-      },
       "eu-north-1": Object {
         "states": "states.eu-north-1.amazonaws.com",
       },
@@ -694,7 +691,6 @@ Object {
   },
   "Resources": Object {
     "DistributedSemaphoreAcquireSemaphoreStateMachine11CA7A20": Object {
-      "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "DistributedSemaphoreAcquireSemaphoreStateMachineRoleDefaultPolicy8F27372C",
         "DistributedSemaphoreAcquireSemaphoreStateMachineRoleFCBD4625",
@@ -740,7 +736,6 @@ Object {
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
-      "UpdateReplacePolicy": "Delete",
     },
     "DistributedSemaphoreAcquireSemaphoreStateMachineRoleDefaultPolicy8F27372C": Object {
       "Properties": Object {
@@ -865,7 +860,6 @@ Object {
       "Type": "AWS::IAM::Role",
     },
     "DistributedSemaphoreCleanupSemaphoreStateMachine74D1E441": Object {
-      "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "DistributedSemaphoreCleanupSemaphoreStateMachineRoleDefaultPolicyD920CE03",
         "DistributedSemaphoreCleanupSemaphoreStateMachineRole2FB995B5",
@@ -903,7 +897,6 @@ Object {
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
-      "UpdateReplacePolicy": "Delete",
     },
     "DistributedSemaphoreCleanupSemaphoreStateMachineEventsRole911C317B": Object {
       "Properties": Object {
@@ -1041,7 +1034,6 @@ Object {
       "Type": "AWS::IAM::Policy",
     },
     "DistributedSemaphoreReleaseSemaphoreStateMachine15A1EC10": Object {
-      "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "DistributedSemaphoreReleaseSemaphoreStateMachineRoleDefaultPolicy6BAFBCEB",
         "DistributedSemaphoreReleaseSemaphoreStateMachineRole927C85D8",
@@ -1071,7 +1063,6 @@ Object {
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
-      "UpdateReplacePolicy": "Delete",
     },
     "DistributedSemaphoreReleaseSemaphoreStateMachineRole927C85D8": Object {
       "Properties": Object {
@@ -1205,7 +1196,6 @@ Object {
       "UpdateReplacePolicy": "Retain",
     },
     "SemaphoreE4816963": Object {
-      "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "SemaphoreRoleDefaultPolicy3FABCD2F",
         "SemaphoreRole7E0FA103",
@@ -1291,7 +1281,6 @@ Object {
         },
       },
       "Type": "AWS::StepFunctions::StateMachine",
-      "UpdateReplacePolicy": "Delete",
     },
     "SemaphoreRole7E0FA103": Object {
       "Properties": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,25 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/aws-lambda-python-alpha@^2.52.0-alpha.0":
-  version "2.52.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.52.0-alpha.0.tgz#7be412d141be599e2d17d0f7d436d56715e304c9"
-  integrity sha512-pw5QTu0rGCRR+JbVL9pOwaLbA+No2vYtl5UjxpFMeiVT+0DnPvdP2p0jEgnsgWFWK8cugy4+XGDWIjFhllLOtw==
+"@aws-cdk/asset-awscli-v1@^2.2.97":
+  version "2.2.158"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.158.tgz#c391c5d1ff9cf367c33096a98a4947cf8b690099"
+  integrity sha512-Qa9SojPKGfEOA0HPdpHw9NfCm2o7lZ3rU/fXWKOi1QS0LkawI8zhxHC+t29/ljs5Gtg1eZ2kzm5cl/DbccPxng==
+
+"@aws-cdk/asset-kubectl-v20@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz#d01c1efb867fb7f2cfd8c8b230b8eae16447e156"
+  integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
+
+"@aws-cdk/asset-node-proxy-agent-v5@^2.0.77":
+  version "2.0.132"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.132.tgz#29ddb0222d8096a3965dbc7afd8d43f7998c5618"
+  integrity sha512-qYKM06QmQAquucitzZw6KglAF5R/quRJMRhBTmSewmnTU3TGZtIQ3JVqC+hx56bXHRtBDE1VTdTxJlmCS4WE9Q==
+
+"@aws-cdk/aws-lambda-python-alpha@2.77.0-alpha.0":
+  version "2.77.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.77.0-alpha.0.tgz#c8fd1d0cad6774bb5d4f153005e29b76302bb336"
+  integrity sha512-3OGqG2O1CE7570gBpcxdRJkAiMJvpm2r5N3pYo8E+tzTAGcqfqlPwDbTE5MgBCNSEbCr3dvNtOU7fKRCUCGwnQ==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
@@ -1054,6 +1069,16 @@ ajv@^6.10.0, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.0.1:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ajv@^8.11.0:
   version "8.11.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.2.tgz#aecb20b50607acf2569b6382167b65a96008bb78"
@@ -1187,6 +1212,11 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
 
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
 async@^3.1.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
@@ -1202,19 +1232,23 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-cdk-lib@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.10.0.tgz#0afbf3754e92855dbb0b6407f85165c25b1c46da"
-  integrity sha512-sMQvQzDqfHumbDOwH2nnyu/sKl7HMi4LkIDRlhW/dLZhYiLvEbwA8ZUclY9g5NuSihF+3G9x1uOjBETBGp+rTg==
+aws-cdk-lib@2.77.0:
+  version "2.77.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.77.0.tgz#803031c2457bc5786ed14fbb967788fd526a9358"
+  integrity sha512-T0GUFHBY1B+LkyGk1Df5E1PXwHa7BqvafD4pGvpwWqu8Mu9s/i0kp8YJu6xY//hEC5R8O7V6bfyQJ0S9pUqwQg==
   dependencies:
+    "@aws-cdk/asset-awscli-v1" "^2.2.97"
+    "@aws-cdk/asset-kubectl-v20" "^2.1.1"
+    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.77"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"
-    ignore "^5.2.0"
-    jsonschema "^1.4.0"
-    minimatch "^3.0.4"
-    punycode "^2.1.1"
-    semver "^7.3.5"
+    ignore "^5.2.4"
+    jsonschema "^1.4.1"
+    minimatch "^3.1.2"
+    punycode "^2.3.0"
+    semver "^7.3.8"
+    table "^6.8.1"
     yaml "1.10.2"
 
 babel-jest@^27.5.1:
@@ -1665,10 +1699,10 @@ console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
-constructs@10.0.5:
-  version "10.0.5"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.5.tgz#48c0402f1b98bbf5664efff74a8015e6e8a9f41e"
-  integrity sha512-IwOwekzrASFC3qt4ozCtV09rteAIAesuCGsW0p+uBfqHd2XcvA5CXqJjgf4eUqm6g8e/noXlVCMDWwC8GaLtrg==
+constructs@10.2.12:
+  version "10.2.12"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.2.12.tgz#5209852dd13be17f33ea3200c775578e2981e948"
+  integrity sha512-aBX/fxAgJgZaX2SL6rdUap8UIWAY1lv6xK/stB1EJ3TFpSEDApd6ZCG40hvK/243H13m0MilvCrmyfyKTdiPlQ==
 
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"
@@ -3003,6 +3037,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.1.tgz#c2b1f76cb999ede1502f3a226a9310fdfe88d46c"
   integrity sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==
 
+ignore@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -4012,7 +4051,7 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-jsonschema@^1.4.0:
+jsonschema@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
   integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
@@ -4130,6 +4169,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 lodash@^4.11.2, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
@@ -5038,6 +5082,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+punycode@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
 pupa@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.1.tgz#f5e8fd4afc2c5d97828faa523549ed8744a20d62"
@@ -5460,6 +5509,15 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
 smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
@@ -5743,6 +5801,17 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+table@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
+  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 tar@^6.1.11, tar@^6.1.2:
   version "6.1.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,10 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.132.tgz#29ddb0222d8096a3965dbc7afd8d43f7998c5618"
   integrity sha512-qYKM06QmQAquucitzZw6KglAF5R/quRJMRhBTmSewmnTU3TGZtIQ3JVqC+hx56bXHRtBDE1VTdTxJlmCS4WE9Q==
 
-"@aws-cdk/aws-lambda-python-alpha@2.77.0-alpha.0":
-  version "2.77.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.77.0-alpha.0.tgz#c8fd1d0cad6774bb5d4f153005e29b76302bb336"
-  integrity sha512-3OGqG2O1CE7570gBpcxdRJkAiMJvpm2r5N3pYo8E+tzTAGcqfqlPwDbTE5MgBCNSEbCr3dvNtOU7fKRCUCGwnQ==
+"@aws-cdk/aws-lambda-python-alpha@2.63.0-alpha.0":
+  version "2.63.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.63.0-alpha.0.tgz#6db70edbbf92af0fb19a57357ecdf8ef41e078c2"
+  integrity sha512-UZnzCHXa3BcM4cebs/i4k5khMYCtUTkJztJwo/lI2sAyRGJHKGP2yzxrNp5DS6YygWsUZddDATyjj32azHBEig==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/asset-awscli-v1@^2.2.97":
+"@aws-cdk/asset-awscli-v1@^2.2.52":
   version "2.2.158"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.158.tgz#c391c5d1ff9cf367c33096a98a4947cf8b690099"
   integrity sha512-Qa9SojPKGfEOA0HPdpHw9NfCm2o7lZ3rU/fXWKOi1QS0LkawI8zhxHC+t29/ljs5Gtg1eZ2kzm5cl/DbccPxng==
@@ -20,7 +20,7 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz#d01c1efb867fb7f2cfd8c8b230b8eae16447e156"
   integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
 
-"@aws-cdk/asset-node-proxy-agent-v5@^2.0.77":
+"@aws-cdk/asset-node-proxy-agent-v5@^2.0.42":
   version "2.0.132"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.132.tgz#29ddb0222d8096a3965dbc7afd8d43f7998c5618"
   integrity sha512-qYKM06QmQAquucitzZw6KglAF5R/quRJMRhBTmSewmnTU3TGZtIQ3JVqC+hx56bXHRtBDE1VTdTxJlmCS4WE9Q==
@@ -1069,16 +1069,6 @@ ajv@^6.10.0, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
-  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
 ajv@^8.11.0:
   version "8.11.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.2.tgz#aecb20b50607acf2569b6382167b65a96008bb78"
@@ -1212,11 +1202,6 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
 
-astral-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
-  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
-
 async@^3.1.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
@@ -1232,14 +1217,14 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-cdk-lib@2.77.0:
-  version "2.77.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.77.0.tgz#803031c2457bc5786ed14fbb967788fd526a9358"
-  integrity sha512-T0GUFHBY1B+LkyGk1Df5E1PXwHa7BqvafD4pGvpwWqu8Mu9s/i0kp8YJu6xY//hEC5R8O7V6bfyQJ0S9pUqwQg==
+aws-cdk-lib@2.63.0:
+  version "2.63.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.63.0.tgz#edc3ede69bbdbe56e87cfb4b834a7e2241e9dc04"
+  integrity sha512-+thToi/7coSufwaEafgofTaZERXxFUeEwEIp0SGU0wHz6IbPll5yAzoEIkE51kM8AMCMfqwJddYOjM3qs43cPg==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.97"
+    "@aws-cdk/asset-awscli-v1" "^2.2.52"
     "@aws-cdk/asset-kubectl-v20" "^2.1.1"
-    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.77"
+    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.42"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"
@@ -1248,7 +1233,6 @@ aws-cdk-lib@2.77.0:
     minimatch "^3.1.2"
     punycode "^2.3.0"
     semver "^7.3.8"
-    table "^6.8.1"
     yaml "1.10.2"
 
 babel-jest@^27.5.1:
@@ -1699,10 +1683,10 @@ console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
-constructs@10.2.12:
-  version "10.2.12"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.2.12.tgz#5209852dd13be17f33ea3200c775578e2981e948"
-  integrity sha512-aBX/fxAgJgZaX2SL6rdUap8UIWAY1lv6xK/stB1EJ3TFpSEDApd6ZCG40hvK/243H13m0MilvCrmyfyKTdiPlQ==
+constructs@10.0.5:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.5.tgz#48c0402f1b98bbf5664efff74a8015e6e8a9f41e"
+  integrity sha512-IwOwekzrASFC3qt4ozCtV09rteAIAesuCGsW0p+uBfqHd2XcvA5CXqJjgf4eUqm6g8e/noXlVCMDWwC8GaLtrg==
 
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"
@@ -4170,11 +4154,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.truncate@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
-  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
-
 lodash@^4.11.2, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -5509,15 +5488,6 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slice-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
-  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
-
 smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
@@ -5801,17 +5771,6 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
-
-table@^6.8.1:
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
-  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
-  dependencies:
-    ajv "^8.0.1"
-    lodash.truncate "^4.4.2"
-    slice-ansi "^4.0.0"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
 
 tar@^6.1.11, tar@^6.1.2:
   version "6.1.12"


### PR DESCRIPTION
[aws-cdk v 2.63.0](https://github.com/aws/aws-cdk/releases/tag/v2.63.0) introduced taskTimeout and heartbeatTimeout instead of timeout and heartbeat, deprecating the old property names.

This change is backwards-compatible and falls back to setting the `taskTimeout` based on the duration if it's provided.

Fixes #